### PR TITLE
update versions due to 'inconsistent' error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,11 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <saxon.version>9.1.0.8</saxon.version>
-	<xunit.plugin.version>1.60</xunit.plugin.version>
-	<analysis.core.plugin.version>1.21</analysis.core.plugin.version>
-	<analysis.test.plugin.version>1.6</analysis.test.plugin.version>
+	    <xunit.plugin.version>1.60</xunit.plugin.version>
+	    <analysis.core.plugin.version>1.34</analysis.core.plugin.version>
+	    <analysis.test.plugin.version>1.7</analysis.test.plugin.version>
         <junit.version>4.9</junit.version>
-	<xmlunit.version>1.3</xmlunit.version>
+	    <xmlunit.version>1.3</xmlunit.version>
         <xercesImpl.version>2.8.1</xercesImpl.version>
     </properties>
 


### PR DESCRIPTION
Analysis-core and Analysis-test used org.jvnet.hudson.main:maven-plugin 1.395 which is
inconsistent with org.jenkins-ci.plugins:maven-plugin 1.410 (version of the current
parrent). Updated respectively to 1.34 and 1.7 to use Analysis-pom 1.33 which doesn't
have a dependency to org.jvnet.hudson.main:maven-plugin
