### PR TITLE
typo: s/faildedIfNotNew/failIfNotNew/

### DIFF
--- a/src/main/java/com/thalesgroup/hudson/plugins/cpptest/CpptestPluginType.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cpptest/CpptestPluginType.java
@@ -15,8 +15,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class CpptestPluginType extends TestType {
 
     @DataBoundConstructor
-    public CpptestPluginType(String pattern, boolean faildedIfNotNew, boolean deleteOutputFiles) {
-        super(pattern, faildedIfNotNew, deleteOutputFiles);
+    public CpptestPluginType(String pattern, boolean failIfNotNew, boolean deleteOutputFiles) {
+        super(pattern, failIfNotNew, deleteOutputFiles);
     }
 
     public TestTypeDescriptor<?> getDescriptor() {


### PR DESCRIPTION
Jenkins couldn't figure out automatically which parameter to bind,
and it was always set to `false`, boolean's default value.
