### PR TITLE
[JENKINS-65161] Remove usage of Digester taken from Jenkins Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,15 +140,6 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <version>2.0</version>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>6</source>
-                    <target>6</target>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <artifactId>xercesImpl</artifactId>
             <version>${xercesImpl.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-digester3</artifactId>
+            <version>3.2</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -133,6 +139,14 @@
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <version>2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>6</source>
+                    <target>6</target>
+                </configuration>
             </plugin>
 
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <saxon.version>9.1.0.8</saxon.version>
         <xunit.plugin.version>1.91</xunit.plugin.version>
         <analysis.core.plugin.version>1.34</analysis.core.plugin.version>
@@ -132,16 +132,7 @@
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>1.67</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.sun</groupId>
-                        <artifactId>tools</artifactId>
-                        <version>1.7</version>
-                        <scope>system</scope>
-                        <systemPath>${env.JAVA_HOME}/lib/tools.jar</systemPath>
-                    </dependency>
-                </dependencies>
+                <version>2.0</version>
             </plugin>
 
         </plugins>

--- a/src/main/java/com/thalesgroup/hudson/plugins/cpptest/VersionParser.java
+++ b/src/main/java/com/thalesgroup/hudson/plugins/cpptest/VersionParser.java
@@ -1,9 +1,10 @@
 package com.thalesgroup.hudson.plugins.cpptest;
 
-import org.apache.commons.digester.Digester;
+import org.apache.commons.digester3.Digester;
 import org.apache.commons.lang.StringUtils;
 import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 
@@ -13,7 +14,12 @@ import java.io.IOException;
 class VersionParser {
 
     static String parse(File file) throws IOException {
-        final Digester digester = new Digester();
+        final Digester digester;
+        try {
+            digester = createDigester(!Boolean.getBoolean(VersionParser.class.getName() + ".UNSAFE"));
+        } catch (SAXException e) {
+            throw new IOException(e); // same handling than later in this method
+        }
         digester.setValidating(false);
         digester.setClassLoader(VersionParser.class.getClassLoader());
 
@@ -46,5 +52,21 @@ class VersionParser {
         public void setToolVer(String toolVer) {
             this.toolVer = toolVer;
         }
+    }
+    
+    private static Digester createDigester(boolean secure) throws SAXException {
+        Digester digester = new Digester();
+        if (secure) {
+            digester.setXIncludeAware(false);
+            try {
+                digester.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                digester.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                digester.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                digester.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            } catch (ParserConfigurationException ex) {
+                throw new SAXException("Failed to securely configure xml digester parser", ex);
+            }
+        }
+        return digester;
     }
 }

--- a/src/main/resources/hudson/plugins/cpptest/CpptestPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/cpptest/CpptestPublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:u="/util">
   <f:entry title="${%Cpptest results}"

--- a/src/main/resources/hudson/plugins/cpptest/CpptestPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/cpptest/CpptestPublisher/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!-- nothing to configure -->
 </j:jelly>

--- a/src/main/resources/hudson/plugins/cpptest/CpptestReporter/config.jelly
+++ b/src/main/resources/hudson/plugins/cpptest/CpptestReporter/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:u="/util">
   <f:advanced>

--- a/src/main/resources/hudson/plugins/cpptest/CpptestReporter/global.jelly
+++ b/src/main/resources/hudson/plugins/cpptest/CpptestReporter/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!-- nothing to configure -->
 </j:jelly>

--- a/src/main/resources/hudson/plugins/cpptest/CpptestResult/index.jelly
+++ b/src/main/resources/hudson/plugins/cpptest/CpptestResult/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
 	xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
 	xmlns:f="/lib/form" xmlns:i="jelly:fmt">

--- a/src/main/resources/hudson/plugins/cpptest/CpptestResultAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/cpptest/CpptestResultAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
 	xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
 	xmlns:f="/lib/form" xmlns:i="jelly:fmt">

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plug-in collects the Parasoft C++test code stantard results of the project modules and visualizes the found warnings.
 </div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This is a follow up PR for jenkinsci/jenkins#5320 tracked by issues.jenkins.io/browse/JENKINS-65161

We're removing Digester from Jenkins core because it's not used there. This PR adds Digester to this plugin and builds the object to parse xmls safely.

I had to fix some warnings linter were yelling.

I kept the build of the Digester isolated on each class. There are two very different packages in this plugin and I ignored the dependency between them intended, so I thought it's better to duplicate this snippet than breaking anything.

Maintainers: @gbois
Additional reviewers: @olamy @jtnord @bitwiseman @car-roll @rsandell @alecharp 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
